### PR TITLE
[cruise-control] Fix CC and improve rebalance algorithm 

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskPlanner.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskPlanner.java
@@ -200,6 +200,12 @@ public class ExecutionTaskPlanner {
                                                                 Set<TopicPartition> inProgressPartitions) {
     LOG.trace("Getting inter-broker replica movement tasks for brokers with concurrency {}", readyBrokers);
     List<ExecutionTask> executableReplicaMovements = new ArrayList<>();
+
+    if (!inProgressPartitions.isEmpty()) {
+      LOG.info("Skipping getting replica movement tasks. {} in progress yet.", inProgressPartitions.size());
+      return executableReplicaMovements;
+    }
+
     /**
      * The algorithm avoids unfair situation where the available movement slots of a broker is completely taken
      * by another broker. It checks the proposals in a round-robin manner that makes sure each ready broker gets

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskPlanner.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskPlanner.java
@@ -4,7 +4,6 @@
 
 package com.linkedin.kafka.cruisecontrol.executor;
 
-import com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils;
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.executor.strategy.BaseReplicaMovementStrategy;
 import com.linkedin.kafka.cruisecontrol.executor.strategy.ReplicaMovementStrategy;
@@ -228,8 +227,7 @@ public class ExecutionTaskPlanner {
             // involved in this round.
             int sourceBroker = task.proposal().oldLeader();
             Set<Integer> destinationBrokers = task.proposal().replicasToAdd();
-            if (brokerInvolved.contains(sourceBroker)
-                || KafkaCruiseControlUtils.containsAny(brokerInvolved, destinationBrokers)) {
+            if (brokerInvolved.contains(sourceBroker)) {
               continue;
             }
             TopicPartition tp = task.proposal().topicPartition();

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/strategy/AbstractReplicaMovementStrategy.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/strategy/AbstractReplicaMovementStrategy.java
@@ -23,17 +23,7 @@ public abstract class AbstractReplicaMovementStrategy implements ReplicaMovement
   @Override
   public ReplicaMovementStrategy chain(ReplicaMovementStrategy strategy) {
     AbstractReplicaMovementStrategy current = this;
-    return new ReplicaMovementStrategy() {
-      @Override
-      public Map<Integer, SortedSet<ExecutionTask>> applyStrategy(Set<ExecutionTask> replicaMovementTasks, Cluster cluster) {
-        return current.applyStrategy(replicaMovementTasks, cluster);
-      }
-
-      @Override
-      public ReplicaMovementStrategy chain(ReplicaMovementStrategy strategy) {
-        return current.chain(strategy);
-      }
-
+    return new AbstractReplicaMovementStrategy() {
       @Override
       public Comparator<ExecutionTask> taskComparator(Cluster cluster) {
         Comparator<ExecutionTask> comparator1 = current.taskComparator(cluster);

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ParameterUtils.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/parameters/ParameterUtils.java
@@ -520,7 +520,7 @@ public class ParameterUtils {
    */
   static ReplicaMovementStrategy getReplicaMovementStrategy(HttpServletRequest request, KafkaCruiseControlConfig config)
       throws UnsupportedEncodingException {
-    if (!getDryRun(request)) {
+    if (getDryRun(request)) {
       return null;
     }
     List<String> strategies = getListParam(request, REPLICA_MOVEMENT_STRATEGIES_PARAM);


### PR DESCRIPTION
This PR fixes Cruise Control issues and patches it to improve the rebalance algorithm.

Fixes:
1. Fix incorrect DryRun checking when the `replica_movement_strategies` parameter is specified.
2. Fix chaining the replica movement strategies

Improvements:
1. During the tasks' selection round, allows different source brokers for the same destination brokers.
2. Skips getting more replica movement tasks if other tasks are still in progress.

These improvements allow for fetching data from different source brokers and execute rebalancing with the same number of moving replicas.

This [chart](https://grafana.liftoff.io/d/M_8ZUgQZk/daniyar-dev-cc-kafka?orgId=1&from=1583429799022&to=1583437277155) shows how these improvements helped to maximize network utilization on the dev kafka cluster (the network bandwidth was limited by instance type).

![image](https://user-images.githubusercontent.com/47581385/76038349-3d37e980-5efe-11ea-8f8e-dad3b7c9831c.png)
