### PR TITLE
Port improvement in replica movements scheduling to 2.4.18

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskPlanner.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskPlanner.java
@@ -347,8 +347,7 @@ public class ExecutionTaskPlanner {
             int sourceBroker = task.proposal().oldLeader().brokerId();
             Set<Integer> destinationBrokers = task.proposal().replicasToAdd().stream().mapToInt(ReplicaPlacementInfo::brokerId)
                                                   .boxed().collect(Collectors.toSet());
-            if (brokerInvolved.contains(sourceBroker)
-                    || KafkaCruiseControlUtils.containsAny(brokerInvolved, destinationBrokers)) {
+            if (brokerInvolved.contains(sourceBroker)) {
               continue;
             }
             TopicPartition tp = task.proposal().topicPartition();


### PR DESCRIPTION
This change applies liftoff improvements to the new version of Cruise Control.

Previously we applied the following fixes and improvements to version 0.1.69 of Cruise Control as part of https://github.com/liftoffio/cruise-control/pull/1:
1. Fix incorrect DryRun checking
2. Fix chaining the replica movement strategies
3. Allow different source brokers for the same destination brokers
4. Skipping getting more replica movement tasks while others in progress

Fixes 1 and 2 were applied to the upstream version of CC in the past, see comments in https://github.com/linkedin/cruise-control/issues/1126 and https://github.com/linkedin/cruise-control/issues/1127.

Improvement 4 is not needed and harmful with Kafka 2.4 / Cruise Control 2.4 as Kafka now supports modifications of in-progress re-assignments and Cruise Control uses it explicitly.

This change applies improvement 3 as-is. A follow up story to update this improvement and contribute it to the upstream is filed, see https://www.pivotaltracker.com/story/show/174205126.
