### PR TITLE
Implement TopicLeaderDistributionGoal

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/BalancingConstraint.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/BalancingConstraint.java
@@ -25,6 +25,7 @@ public class BalancingConstraint {
   private final Double _replicaBalancePercentage;
   private final Double _leaderReplicaBalancePercentage;
   private final Double _topicReplicaBalancePercentage;
+  private final Double _topicLeaderBalancePercentage;
   private final Double _goalViolationDistributionThresholdMultiplier;
   private final Map<Resource, Double> _capacityThreshold;
   private final Map<Resource, Double> _lowUtilizationThreshold;
@@ -63,6 +64,7 @@ public class BalancingConstraint {
     _replicaBalancePercentage = config.getDouble(AnalyzerConfig.REPLICA_COUNT_BALANCE_THRESHOLD_CONFIG);
     _leaderReplicaBalancePercentage = config.getDouble(AnalyzerConfig.LEADER_REPLICA_COUNT_BALANCE_THRESHOLD_CONFIG);
     _topicReplicaBalancePercentage = config.getDouble(AnalyzerConfig.TOPIC_REPLICA_COUNT_BALANCE_THRESHOLD_CONFIG);
+    _topicLeaderBalancePercentage = config.getDouble(AnalyzerConfig.TOPIC_LEADER_COUNT_BALANCE_THRESHOLD_CONFIG);
     _goalViolationDistributionThresholdMultiplier = config.getDouble(AnalyzerConfig.GOAL_VIOLATION_DISTRIBUTION_THRESHOLD_MULTIPLIER_CONFIG);
   }
 
@@ -86,6 +88,7 @@ public class BalancingConstraint {
     props.put(AnalyzerConfig.REPLICA_COUNT_BALANCE_THRESHOLD_CONFIG, _replicaBalancePercentage.toString());
     props.put(AnalyzerConfig.LEADER_REPLICA_COUNT_BALANCE_THRESHOLD_CONFIG, _leaderReplicaBalancePercentage.toString());
     props.put(AnalyzerConfig.TOPIC_REPLICA_COUNT_BALANCE_THRESHOLD_CONFIG, _topicReplicaBalancePercentage.toString());
+    props.put(AnalyzerConfig.TOPIC_LEADER_COUNT_BALANCE_THRESHOLD_CONFIG, _topicLeaderBalancePercentage.toString());
     props.put(AnalyzerConfig.GOAL_VIOLATION_DISTRIBUTION_THRESHOLD_MULTIPLIER_CONFIG,
               _goalViolationDistributionThresholdMultiplier.toString());
     return props;
@@ -125,6 +128,14 @@ public class BalancingConstraint {
    */
   public Double topicReplicaBalancePercentage() {
     return _topicReplicaBalancePercentage;
+  }
+
+  /**
+   * @return Topic leader replica balance percentage for
+   * {@link com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicLeaderDistributionGoal}.
+   */
+  public Double topicLeaderBalancePercentage() {
+    return _topicLeaderBalancePercentage;
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/TopicLeaderDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/TopicLeaderDistributionGoal.java
@@ -192,7 +192,7 @@ public class TopicLeaderDistributionGoal extends AbstractGoal {
 
   @Override
   public ClusterModelStatsComparator clusterModelStatsComparator() {
-    return new TopicReplicaDistrGoalStatsComparator();
+    return new TopicLeaderDistrGoalStatsComparator();
   }
 
   @Override
@@ -498,12 +498,12 @@ public class TopicLeaderDistributionGoal extends AbstractGoal {
     return true;
   }
 
-  private class TopicReplicaDistrGoalStatsComparator implements ClusterModelStatsComparator {
+  private class TopicLeaderDistrGoalStatsComparator implements ClusterModelStatsComparator {
     private String _reasonForLastNegativeResult;
 
     @Override
     public int compare(ClusterModelStats stats1, ClusterModelStats stats2) {
-      // Standard deviation of number of topic replicas over brokers in the current must be less than the
+      // Standard deviation of number of topic leader replicas over brokers in the current must be less than the
       // pre-optimized stats.
       double stdDev1 = stats1.topicLeaderStats().get(Statistic.ST_DEV).doubleValue();
       double stdDev2 = stats2.topicLeaderStats().get(Statistic.ST_DEV).doubleValue();

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/TopicLeaderDistributionGoal.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/analyzer/goals/TopicLeaderDistributionGoal.java
@@ -1,0 +1,523 @@
+/*
+ * Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ *
+ */
+
+package com.linkedin.kafka.cruisecontrol.analyzer.goals;
+
+import com.linkedin.kafka.cruisecontrol.analyzer.OptimizationOptions;
+import com.linkedin.kafka.cruisecontrol.analyzer.ActionAcceptance;
+import com.linkedin.kafka.cruisecontrol.analyzer.ActionType;
+import com.linkedin.kafka.cruisecontrol.analyzer.AnalyzerUtils;
+import com.linkedin.kafka.cruisecontrol.analyzer.BalancingConstraint;
+import com.linkedin.kafka.cruisecontrol.analyzer.BalancingAction;
+import com.linkedin.kafka.cruisecontrol.common.Statistic;
+import com.linkedin.kafka.cruisecontrol.exception.OptimizationFailureException;
+import com.linkedin.kafka.cruisecontrol.model.Broker;
+import com.linkedin.kafka.cruisecontrol.model.ClusterModel;
+import com.linkedin.kafka.cruisecontrol.model.ClusterModelStats;
+import com.linkedin.kafka.cruisecontrol.model.Replica;
+import com.linkedin.kafka.cruisecontrol.monitor.ModelCompletenessRequirements;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.stream.Collectors;
+
+import static com.linkedin.kafka.cruisecontrol.analyzer.ActionAcceptance.ACCEPT;
+import static com.linkedin.kafka.cruisecontrol.analyzer.ActionAcceptance.REPLICA_REJECT;
+import static com.linkedin.kafka.cruisecontrol.analyzer.AnalyzerUtils.EPSILON;
+import static com.linkedin.kafka.cruisecontrol.analyzer.goals.GoalUtils.MIN_NUM_VALID_WINDOWS_FOR_SELF_HEALING;
+import static com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionAbstractGoal.ChangeType.ADD;
+import static com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionAbstractGoal.ChangeType.REMOVE;
+
+
+/**
+ * Soft goal to balance the number of leader replicas of each topic.
+ * <ul>
+ * <li>Under: (the average number of topic leader replicas per broker) * (1 + topic leader replica count balance percentage)</li>
+ * <li>Above: (the average number of topic leader replicas per broker) * Math.max(0, 1 - topic leader replica count balance percentage)</li>
+ * </ul>
+ * Also see: {@link com.linkedin.kafka.cruisecontrol.config.constants.AnalyzerConfig#TOPIC_LEADER_COUNT_BALANCE_THRESHOLD_CONFIG},
+ * {@link com.linkedin.kafka.cruisecontrol.config.constants.AnalyzerConfig#GOAL_VIOLATION_DISTRIBUTION_THRESHOLD_MULTIPLIER_CONFIG},
+ * and {@link #balancePercentageWithMargin(OptimizationOptions)}.
+ */
+public class TopicLeaderDistributionGoal extends AbstractGoal {
+  private static final Logger LOG = LoggerFactory.getLogger(TopicLeaderDistributionGoal.class);
+  private static final double BALANCE_MARGIN = 0.9;
+  // Flag to indicate whether the self healing failed to relocate all offline replicas away from dead brokers or broken
+  // disks in its initial attempt and currently omitting the replica balance limit to relocate remaining replicas.
+  private boolean _fixOfflineReplicasOnly;
+
+  private final Map<String, Set<Integer>> _brokerIdsAboveBalanceUpperLimitByTopic;
+  private final Map<String, Set<Integer>> _brokerIdsUnderBalanceLowerLimitByTopic;
+  // Must contain only the topics to be rebalanced.
+  private final Map<String, Double> _avgTopicReplicasOnAliveBroker;
+  // Must contain all topics to ensure that the lower priority goals work w/o an NPE.
+  private final Map<String, Integer> _balanceUpperLimitByTopic;
+  private final Map<String, Integer> _balanceLowerLimitByTopic;
+
+  /**
+   * A soft goal to balance collocations of leader replicas of the same topic.
+   */
+  public TopicLeaderDistributionGoal() {
+    _brokerIdsAboveBalanceUpperLimitByTopic = new HashMap<>();
+    _brokerIdsUnderBalanceLowerLimitByTopic = new HashMap<>();
+    _avgTopicReplicasOnAliveBroker = new HashMap<>();
+    _balanceUpperLimitByTopic = new HashMap<>();
+    _balanceLowerLimitByTopic = new HashMap<>();
+  }
+
+  public TopicLeaderDistributionGoal(BalancingConstraint balancingConstraint) {
+    this();
+    _balancingConstraint = balancingConstraint;
+  }
+
+  /**
+   * To avoid churns, we add a balance margin to the user specified rebalance threshold. e.g. when user sets the
+   * threshold to be {@link BalancingConstraint#topicLeaderBalancePercentage()}, we use
+   * ({@link BalancingConstraint#topicLeaderBalancePercentage()}-1)*{@link #BALANCE_MARGIN} instead.
+   *
+   * @param optimizationOptions Options to adjust balance percentage with margin in case goal optimization is triggered
+   * by goal violation detector.
+   * @return The rebalance threshold with a margin.
+   */
+  private double balancePercentageWithMargin(OptimizationOptions optimizationOptions) {
+    double balancePercentage = optimizationOptions.isTriggeredByGoalViolation()
+                               ? _balancingConstraint.topicLeaderBalancePercentage()
+                                 * _balancingConstraint.goalViolationDistributionThresholdMultiplier()
+                               : _balancingConstraint.topicLeaderBalancePercentage();
+
+    return (balancePercentage - 1) * BALANCE_MARGIN;
+  }
+
+  /**
+   * @param topic Topic for which the upper limit is requested.
+   * @param optimizationOptions Options to adjust balance upper limit in case goal optimization is triggered by goal
+   * violation detector.
+   * @return The topic replica balance upper threshold in number of topic replicas.
+   */
+  private int balanceUpperLimit(String topic, OptimizationOptions optimizationOptions) {
+    return (int) Math.ceil(_avgTopicReplicasOnAliveBroker.get(topic)
+                           * (1 + balancePercentageWithMargin(optimizationOptions)));
+  }
+
+  /**
+   * @param topic Topic for which the lower limit is requested.
+   * @param optimizationOptions Options to adjust balance lower limit in case goal optimization is triggered by goal
+   * violation detector.
+   * @return The replica balance lower threshold in number of topic replicas.
+   */
+  private int balanceLowerLimit(String topic, OptimizationOptions optimizationOptions) {
+    return (int) Math.floor(_avgTopicReplicasOnAliveBroker.get(topic)
+                            * Math.max(0, (1 - balancePercentageWithMargin(optimizationOptions))));
+  }
+
+  /**
+   * Check whether the given action is acceptable by this goal. An action is acceptable if the number of topic leader replicas at
+   * (1) the source broker does not go under the allowed limit.
+   * (2) the destination broker does not go over the allowed limit.
+   *
+   * @param action Action to be checked for acceptance.
+   * @param clusterModel The state of the cluster.
+   * @return {@link ActionAcceptance#ACCEPT} if the action is acceptable by this goal,
+   * {@link ActionAcceptance#REPLICA_REJECT} otherwise.
+   */
+  @Override
+  public ActionAcceptance actionAcceptance(BalancingAction action, ClusterModel clusterModel) {
+    Broker sourceBroker = clusterModel.broker(action.sourceBrokerId());
+    Replica sourceReplica = sourceBroker.replica(action.topicPartition());
+    Broker destinationBroker = clusterModel.broker(action.destinationBrokerId());
+    String sourceTopic = action.topic();
+
+    boolean accept = true;
+
+    switch (action.balancingAction()) {
+      case INTER_BROKER_REPLICA_SWAP:
+        String destinationTopic = action.destinationTopic();
+        Replica destinationReplica = destinationBroker.replica(action.destinationTopicPartition());
+        if (sourceTopic.equals(destinationTopic) && sourceReplica.isLeader() == destinationReplica.isLeader()) {
+          break;
+        }
+        if (sourceReplica.isLeader()) {
+          accept &= isLeaderMovementSatisfiable(sourceTopic, sourceBroker, destinationBroker);
+        }
+        if (destinationReplica.isLeader()) {
+          accept &= isLeaderMovementSatisfiable(destinationTopic, destinationBroker, sourceBroker);
+        }
+        break;
+      case INTER_BROKER_REPLICA_MOVEMENT:
+        if (sourceReplica.isLeader()) {
+          accept = isLeaderMovementSatisfiable(sourceTopic, sourceBroker, destinationBroker);
+        }
+        break;
+      case LEADERSHIP_MOVEMENT:
+        accept = isLeaderMovementSatisfiable(sourceTopic, sourceBroker, destinationBroker);
+        break;
+      default:
+        throw new IllegalArgumentException("Unsupported balancing action " + action.balancingAction() + " is provided.");
+    }
+
+    return accept ? ACCEPT : REPLICA_REJECT;
+  }
+
+  private boolean isLeaderMovementSatisfiable(String topic, Broker sourceBroker, Broker destinationBroker) {
+    return isReplicaCountUnderBalanceUpperLimitAfterChange(topic, destinationBroker, ADD)
+            && isReplicaCountAboveBalanceLowerLimitAfterChange(topic, sourceBroker, REMOVE);
+  }
+
+  private boolean isReplicaCountUnderBalanceUpperLimitAfterChange(String topic,
+                                                                  Broker broker,
+                                                                  ReplicaDistributionGoal.ChangeType changeType) {
+    int numTopicReplicas = broker.numLeadersOfTopicInBroker(topic);
+    int brokerBalanceUpperLimit = broker.isAlive() ? _balanceUpperLimitByTopic.get(topic) : 0;
+
+    return changeType == ADD ? numTopicReplicas + 1 <= brokerBalanceUpperLimit : numTopicReplicas - 1 <= brokerBalanceUpperLimit;
+  }
+
+  private boolean isReplicaCountAboveBalanceLowerLimitAfterChange(String topic,
+                                                                  Broker broker,
+                                                                  ReplicaDistributionGoal.ChangeType changeType) {
+    int numTopicReplicas = broker.numLeadersOfTopicInBroker(topic);
+    int brokerBalanceLowerLimit = broker.isAlive() ? _balanceLowerLimitByTopic.get(topic) : 0;
+
+    return changeType == ADD ? numTopicReplicas + 1 >= brokerBalanceLowerLimit : numTopicReplicas - 1 >= brokerBalanceLowerLimit;
+  }
+
+  @Override
+  public ClusterModelStatsComparator clusterModelStatsComparator() {
+    return new TopicReplicaDistrGoalStatsComparator();
+  }
+
+  @Override
+  public ModelCompletenessRequirements clusterModelCompletenessRequirements() {
+    return new ModelCompletenessRequirements(MIN_NUM_VALID_WINDOWS_FOR_SELF_HEALING, 0.0, true);
+  }
+
+  /**
+   * Get the name of this goal. Name of a goal provides an identification for the goal in human readable format.
+   */
+  @Override
+  public String name() {
+    return TopicLeaderDistributionGoal.class.getSimpleName();
+  }
+
+  @Override
+  public boolean isHardGoal() {
+    return false;
+  }
+
+  /**
+   * Get brokers that the rebalance process will go over to apply balancing actions to replicas they contain.
+   *
+   * @param clusterModel The state of the cluster.
+   * @return A collection of brokers that the rebalance process will go over to apply balancing actions to replicas
+   * they contain.
+   */
+  @Override
+  protected SortedSet<Broker> brokersToBalance(ClusterModel clusterModel) {
+    return clusterModel.brokers();
+  }
+
+  /**
+   * Get the set of topics to rebalance. If there are self healing eligible replicas, gets only their topics.
+   * Otherwise gets all topics except excludedTopics.
+   *
+   * @return The set of topics to rebalance.
+   */
+  private Set<String> topicsToRebalance(ClusterModel clusterModel, Set<String> excludedTopics) {
+    Set<String> topicsToRebalance;
+    if (!clusterModel.selfHealingEligibleReplicas().isEmpty()) {
+      topicsToRebalance = new HashSet<>();
+      for (Replica replica : clusterModel.selfHealingEligibleReplicas()) {
+        topicsToRebalance.add(replica.topicPartition().topic());
+      }
+    } else {
+      topicsToRebalance = new HashSet<>(clusterModel.topics());
+      topicsToRebalance.removeAll(excludedTopics);
+    }
+
+    if (topicsToRebalance.isEmpty()) {
+      LOG.warn("All topics are excluded from {}.", name());
+    }
+
+    return topicsToRebalance;
+  }
+
+  /**
+   * Initiates this goal.
+   *
+   * @param clusterModel The state of the cluster.
+   * @param optimizationOptions Options to take into account during optimization.
+   */
+  @Override
+  protected void initGoalState(ClusterModel clusterModel, OptimizationOptions optimizationOptions) {
+    Set<String> excludedTopics = optimizationOptions.excludedTopics();
+    Set<String> topicsToRebalance = topicsToRebalance(clusterModel, excludedTopics);
+
+    // Initialize the average leader replicas on an alive broker.
+    for (String topic : clusterModel.topics()) {
+      int numTopicLeaders = clusterModel.numTopicLeaders(topic);
+      _avgTopicReplicasOnAliveBroker.put(topic, (numTopicLeaders / (double) clusterModel.aliveBrokers().size()));
+      _balanceUpperLimitByTopic.put(topic, balanceUpperLimit(topic, optimizationOptions));
+      _balanceLowerLimitByTopic.put(topic, balanceLowerLimit(topic, optimizationOptions));
+      // Retain only the topics to rebalance in _avgTopicReplicasOnAliveBroker
+      if (!topicsToRebalance.contains(topic)) {
+        _avgTopicReplicasOnAliveBroker.remove(topic);
+      }
+    }
+    _fixOfflineReplicasOnly = false;
+  }
+
+  /**
+   * Check if requirements of this goal are not violated if this proposal is applied to the given cluster state,
+   * false otherwise.
+   *
+   * @param clusterModel The state of the cluster.
+   * @param action Action containing information about potential modification to the given cluster model. Assumed to be
+   * of type {@link ActionType#INTER_BROKER_REPLICA_MOVEMENT}.
+   * @return True if requirements of this goal are not violated if this proposal is applied to the given cluster state,
+   * false otherwise.
+   */
+  @Override
+  protected boolean selfSatisfied(ClusterModel clusterModel, BalancingAction action) {
+    Broker sourceBroker = clusterModel.broker(action.sourceBrokerId());
+    // The action must be executed if currently fixing offline replicas only and the offline source replica is proposed
+    // to be moved to another broker.
+    if (_fixOfflineReplicasOnly && sourceBroker.replica(action.topicPartition()).isCurrentOffline()) {
+      return action.balancingAction() == ActionType.INTER_BROKER_REPLICA_MOVEMENT;
+    }
+
+    //Check that destination and source would not become unbalanced.
+    Broker destinationBroker = clusterModel.broker(action.destinationBrokerId());
+    String sourceTopic = action.topic();
+
+    return isReplicaCountUnderBalanceUpperLimitAfterChange(sourceTopic, destinationBroker, ADD) &&
+           isReplicaCountAboveBalanceLowerLimitAfterChange(sourceTopic, sourceBroker, REMOVE);
+  }
+
+  /**
+   * Update goal state after one round of self-healing / rebalance.
+   * @param clusterModel The state of the cluster.
+   * @param optimizationOptions Options to take into account during optimization.
+   */
+  @Override
+  protected void updateGoalState(ClusterModel clusterModel, OptimizationOptions optimizationOptions)
+      throws OptimizationFailureException {
+    if (!_brokerIdsAboveBalanceUpperLimitByTopic.isEmpty()) {
+      _brokerIdsAboveBalanceUpperLimitByTopic.clear();
+      _succeeded = false;
+    }
+    if (!_brokerIdsUnderBalanceLowerLimitByTopic.isEmpty()) {
+      _brokerIdsUnderBalanceLowerLimitByTopic.clear();
+      _succeeded = false;
+    }
+    // Sanity check: No self-healing eligible replica should remain at a dead broker/disk.
+    try {
+      GoalUtils.ensureNoOfflineReplicas(clusterModel, name());
+    } catch (OptimizationFailureException ofe) {
+      if (_fixOfflineReplicasOnly) {
+        throw ofe;
+      }
+      _fixOfflineReplicasOnly = true;
+      LOG.info("Ignoring topic replica balance limit to move replicas from dead brokers/disks.");
+      return;
+    }
+    // Sanity check: No replica should be moved to a broker, which used to host any replica of the same partition on its broken disk.
+    GoalUtils.ensureReplicasMoveOffBrokersWithBadDisks(clusterModel, name());
+    finish();
+  }
+
+  @Override
+  public void finish() {
+    _finished = true;
+  }
+
+  private static boolean skipBrokerRebalance(Broker broker,
+                                             ClusterModel clusterModel,
+                                             Collection<Replica> replicas,
+                                             boolean requireLessReplicas,
+                                             boolean requireMoreReplicas,
+                                             boolean hasOfflineTopicReplicas,
+                                             boolean moveImmigrantReplicaOnly) {
+    boolean hasImmigrantTopicReplicas = replicas.stream().anyMatch(replica -> broker.immigrantReplicas().contains(replica));
+    if (broker.isAlive() && !requireMoreReplicas && !requireLessReplicas) {
+      LOG.trace("Skip rebalance: Broker {} is already within the limit for replicas {}.", broker, replicas);
+      return true;
+    } else if (!clusterModel.newBrokers().isEmpty() && !broker.isNew() && !requireLessReplicas) {
+      LOG.trace("Skip rebalance: Cluster has new brokers and this broker {} is not new, but does not require less load "
+                + "for replicas {}. Hence, it does not have any offline replicas.", broker, replicas);
+      return true;
+    } else if (!clusterModel.selfHealingEligibleReplicas().isEmpty() && requireLessReplicas
+               && !hasOfflineTopicReplicas && !hasImmigrantTopicReplicas) {
+      LOG.trace("Skip rebalance: Cluster is in self-healing mode and the broker {} requires less load, but none of its "
+                + "current offline or immigrant replicas are from the topic being balanced {}.", broker, replicas);
+      return true;
+    } else if (moveImmigrantReplicaOnly && requireLessReplicas && !hasImmigrantTopicReplicas) {
+      LOG.trace("Skip rebalance: Only immigrant replicas can be moved, but none of broker {}'s "
+                + "current immigrant replicas are from the topic being balanced {}.", broker, replicas);
+      return true;
+    }
+
+    return false;
+  }
+
+  private static Set<Replica> retainCurrentOfflineBrokerReplicas(Broker broker, Collection<Replica> replicas) {
+    Set<Replica> offlineReplicas = new HashSet<>(replicas);
+    offlineReplicas.retainAll(broker.currentOfflineReplicas());
+
+    return offlineReplicas;
+  }
+
+  private boolean isTopicExcludedFromRebalance(String topic) {
+    return _avgTopicReplicasOnAliveBroker.get(topic) == null;
+  }
+
+  /**
+   * Rebalance the given broker without violating the constraints of the current goal and optimized goals.
+   *
+   * @param broker         Broker to be balanced.
+   * @param clusterModel   The state of the cluster.
+   * @param optimizedGoals Optimized goals.
+   * @param optimizationOptions Options to take into account during optimization.
+   */
+  @Override
+  protected void rebalanceForBroker(Broker broker,
+                                    ClusterModel clusterModel,
+                                    Set<Goal> optimizedGoals,
+                                    OptimizationOptions optimizationOptions) {
+    LOG.debug("Rebalancing broker {} [limits] lower: {} upper: {}.", broker.id(), _balanceLowerLimitByTopic,
+              _balanceUpperLimitByTopic);
+
+    for (String topic : broker.topics()) {
+      if (isTopicExcludedFromRebalance(topic)) {
+        continue;
+      }
+
+      Collection<Replica> leaderReplicas = broker.leadersOfTopicInBroker(topic);
+      int numLeaderReplicas = leaderReplicas.size();
+      int numOfflineTopicReplicas = retainCurrentOfflineBrokerReplicas(broker, leaderReplicas).size();
+
+      boolean requireLessReplicas = numOfflineTopicReplicas > 0 || numLeaderReplicas > _balanceUpperLimitByTopic.get(topic);
+      boolean requireMoreReplicas = broker.isAlive() && numLeaderReplicas - numOfflineTopicReplicas < _balanceLowerLimitByTopic.get(topic);
+
+      if (skipBrokerRebalance(broker, clusterModel, leaderReplicas, requireLessReplicas, requireMoreReplicas, numOfflineTopicReplicas > 0,
+                              optimizationOptions.onlyMoveImmigrantReplicas())) {
+        continue;
+      }
+
+      // Update broker ids over the balance limit for logging purposes.
+      if (requireLessReplicas && rebalanceByMovingLeadershipOut(broker, topic, clusterModel, optimizedGoals, optimizationOptions)) {
+        _brokerIdsAboveBalanceUpperLimitByTopic.computeIfAbsent(topic, t -> new HashSet<>()).add(broker.id());
+        LOG.debug("Failed to sufficiently decrease leaders of topic {} in broker {} with leadership movements. Leaders: {}.",
+                  topic, broker.id(), broker.numLeadersOfTopicInBroker(topic));
+      }
+      if (requireMoreReplicas && rebalanceByMovingLeadershipIn(broker, topic, clusterModel, optimizedGoals, optimizationOptions)) {
+        _brokerIdsUnderBalanceLowerLimitByTopic.computeIfAbsent(topic, t -> new HashSet<>()).add(broker.id());
+        LOG.debug("Failed to sufficiently increase leaders of topic {} in broker {} with leadership movements. Leaders: {}.",
+                  topic, broker.id(), broker.numLeadersOfTopicInBroker(topic));
+      }
+      if (!_brokerIdsAboveBalanceUpperLimitByTopic.getOrDefault(topic, Collections.emptySet()).contains(broker.id())
+          && !_brokerIdsUnderBalanceLowerLimitByTopic.getOrDefault(topic, Collections.emptySet()).contains(broker.id())) {
+        LOG.debug("Successfully balanced leaders of topic {} in broker {} by moving leadership. Leaders: {}",
+                  topic, broker.id(), broker.numLeadersOfTopicInBroker(topic));
+      }
+    }
+  }
+
+  private boolean rebalanceByMovingLeadershipOut(Broker broker,
+                                                 String topic,
+                                                 ClusterModel clusterModel,
+                                                 Set<Goal> optimizedGoals,
+                                                 OptimizationOptions optimizationOptions) {
+    if (!clusterModel.deadBrokers().isEmpty()) {
+      return true;
+    }
+    int numLeaderReplicas = broker.leadersOfTopicInBroker(topic).size();
+    Set<String> excludedTopics = optimizationOptions.excludedTopics();
+    for (Replica leader : new HashSet<>(broker.leadersOfTopicInBroker(topic))) {
+      if (excludedTopics.contains(leader.topicPartition().topic())) {
+        continue;
+      }
+
+      Set<Broker> candidateBrokers = clusterModel.partition(leader.topicPartition()).partitionBrokers().stream()
+              .filter(b -> b != broker && !b.replica(leader.topicPartition()).isCurrentOffline())
+              .collect(Collectors.toSet());
+      Broker b = maybeApplyBalancingAction(clusterModel,
+              leader,
+              candidateBrokers,
+              ActionType.LEADERSHIP_MOVEMENT,
+              optimizedGoals,
+              optimizationOptions);
+      // Only check if we successfully moved something.
+      if (b != null) {
+        if (--numLeaderReplicas <= _balanceUpperLimitByTopic.get(topic)) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  private boolean rebalanceByMovingLeadershipIn(Broker broker,
+                                                String topic,
+                                                ClusterModel clusterModel,
+                                                Set<Goal> optimizedGoals,
+                                                OptimizationOptions optimizationOptions) {
+    if (!clusterModel.deadBrokers().isEmpty() ||
+            optimizationOptions.excludedBrokersForLeadership().contains(broker.id())) {
+      return true;
+    }
+
+    int numLeaderReplicas = broker.leadersOfTopicInBroker(topic).size();
+    Set<Broker> candidateBrokers =  Collections.singleton(broker);
+    Set<String> excludedTopics = optimizationOptions.excludedTopics();
+    for (Replica replica : broker.replicasOfTopicInBroker(topic)) {
+      if (replica.isLeader() || replica.isCurrentOffline() || excludedTopics.contains(replica.topicPartition().topic())) {
+        continue;
+      }
+      Broker b = maybeApplyBalancingAction(clusterModel,
+              clusterModel.partition(replica.topicPartition()).leader(),
+              candidateBrokers,
+              ActionType.LEADERSHIP_MOVEMENT,
+              optimizedGoals,
+              optimizationOptions);
+      // Only check if we successfully moved something.
+      if (b != null) {
+        if (++numLeaderReplicas >= _balanceLowerLimitByTopic.get(topic)) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  private class TopicReplicaDistrGoalStatsComparator implements ClusterModelStatsComparator {
+    private String _reasonForLastNegativeResult;
+
+    @Override
+    public int compare(ClusterModelStats stats1, ClusterModelStats stats2) {
+      // Standard deviation of number of topic replicas over brokers in the current must be less than the
+      // pre-optimized stats.
+      double stdDev1 = stats1.topicLeaderStats().get(Statistic.ST_DEV).doubleValue();
+      double stdDev2 = stats2.topicLeaderStats().get(Statistic.ST_DEV).doubleValue();
+      int result = AnalyzerUtils.compare(stdDev2, stdDev1, EPSILON);
+      if (result < 0) {
+        _reasonForLastNegativeResult = String.format("Violated %s. [Std Deviation of Topic Leader Replica Distribution] post-"
+                                                     + "optimization:%.3f pre-optimization:%.3f", name(), stdDev1, stdDev2);
+      }
+      return result;
+    }
+
+    @Override
+    public String explainLastComparison() {
+      return _reasonForLastNegativeResult;
+    }
+  }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/AnalyzerConfig.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/constants/AnalyzerConfig.java
@@ -106,6 +106,15 @@ public class AnalyzerConfig {
       + "should not be above 1.80x of average replica count of all brokers for the same topic.";
 
   /**
+   * <code>topic.leader.count.balance.threshold</code>
+   */
+  public static final String TOPIC_LEADER_COUNT_BALANCE_THRESHOLD_CONFIG = "topic.leader.count.balance.threshold";
+  public static final double DEFAULT_TOPIC_LEADER_COUNT_BALANCE_THRESHOLD = 3.00;
+  public static final String TOPIC_LEADER_COUNT_BALANCE_THRESHOLD_DOC = "The maximum allowed extent of unbalance for "
+          + "leader replica distribution from each topic. For example, 1.80 means the highest topic leader replica count of a broker "
+          + "should not be above 1.80x of average leader replica count of all brokers for the same topic.";
+
+  /**
    * <code>cpu.capacity.threshold</code>
    */
   public static final String CPU_CAPACITY_THRESHOLD_CONFIG = "cpu.capacity.threshold";
@@ -378,6 +387,12 @@ public class AnalyzerConfig {
                             atLeast(1),
                             ConfigDef.Importance.HIGH,
                             TOPIC_REPLICA_COUNT_BALANCE_THRESHOLD_DOC)
+                    .define(TOPIC_LEADER_COUNT_BALANCE_THRESHOLD_CONFIG,
+                            ConfigDef.Type.DOUBLE,
+                            DEFAULT_TOPIC_LEADER_COUNT_BALANCE_THRESHOLD,
+                            atLeast(1),
+                            ConfigDef.Importance.HIGH,
+                            TOPIC_LEADER_COUNT_BALANCE_THRESHOLD_DOC)
                     .define(CPU_CAPACITY_THRESHOLD_CONFIG,
                             ConfigDef.Type.DOUBLE,
                             DEFAULT_CPU_CAPACITY_THRESHOLD,

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskPlanner.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/executor/ExecutionTaskPlanner.java
@@ -4,7 +4,6 @@
 
 package com.linkedin.kafka.cruisecontrol.executor;
 
-import com.linkedin.kafka.cruisecontrol.KafkaCruiseControlUtils;
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.executor.strategy.BaseReplicaMovementStrategy;
 import com.linkedin.kafka.cruisecontrol.executor.strategy.ReplicaMovementStrategy;

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Broker.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Broker.java
@@ -217,11 +217,7 @@ public class Broker implements Serializable, Comparable<Broker> {
    * @return The number of leader replicas from the given topic in this broker.
    */
   public int numLeadersOfTopicInBroker(String topic) {
-    Map<Integer, Replica> topicReplicas = _topicReplicas.get(topic);
-    if (topicReplicas == null) {
-      return 0;
-    }
-    return (int) topicReplicas.values().stream().filter(r -> r.isLeader()).count();
+    return leadersOfTopicInBroker(topic).size();
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Broker.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Broker.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.apache.kafka.common.TopicPartition;
 
@@ -185,6 +186,20 @@ public class Broker implements Serializable, Comparable<Broker> {
   }
 
   /**
+   * Get leader replicas for topic.
+   *
+   * @param topic Topic of the requested replicas.
+   * @return Leader replicas in this broker sharing the given topic.
+   */
+  public Collection<Replica> leadersOfTopicInBroker(String topic) {
+    Map<Integer, Replica> topicReplicas = _topicReplicas.get(topic);
+    if (topicReplicas == null) {
+      return Collections.emptySet();
+    }
+    return topicReplicas.values().stream().filter(r -> r.isLeader()).collect(Collectors.toList());
+  }
+
+  /**
    * Get number of replicas from the given topic in this broker.
    *
    * @param topic Topic for which the replica count will be returned.
@@ -193,6 +208,20 @@ public class Broker implements Serializable, Comparable<Broker> {
   public int numReplicasOfTopicInBroker(String topic) {
     Map<Integer, Replica> topicReplicas = _topicReplicas.get(topic);
     return topicReplicas == null ? 0 : topicReplicas.size();
+  }
+
+  /**
+   * Get number of leader replicas from the given topic in this broker.
+   *
+   * @param topic Topic for which the leader replica count will be returned.
+   * @return The number of leader replicas from the given topic in this broker.
+   */
+  public int numLeadersOfTopicInBroker(String topic) {
+    Map<Integer, Replica> topicReplicas = _topicReplicas.get(topic);
+    if (topicReplicas == null) {
+      return 0;
+    }
+    return (int) topicReplicas.values().stream().filter(r -> r.isLeader()).count();
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ClusterModel.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ClusterModel.java
@@ -631,6 +631,21 @@ public class ClusterModel implements Serializable {
   }
 
   /**
+   * Get the number of leader replicas with the given topic name in cluster.
+   *
+   * @param topic Name of the topic for which the number of leader replicas in cluster will be counted.
+   * @return Number of leader replicas with the given topic name in cluster.
+   */
+  public int numTopicLeaders(String topic) {
+    int numTopicLeaders = 0;
+
+    for (Rack rack : _racksById.values()) {
+      numTopicLeaders += rack.numTopicLeaders(topic);
+    }
+    return numTopicLeaders;
+  }
+
+  /**
    * Get the number of leader replicas in cluster.
    *
    * @return Number of leader replicas in cluster.

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ClusterModelStats.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/ClusterModelStats.java
@@ -33,6 +33,7 @@ public class ClusterModelStats {
   private final Map<Statistic, Number> _replicaStats;
   private final Map<Statistic, Number> _leaderReplicaStats;
   private final Map<Statistic, Number> _topicReplicaStats;
+  private final Map<Statistic, Number> _topicLeaderStats;
   private int _numBrokers;
   private int _numAliveBrokers;
   private int _numReplicasInCluster;
@@ -58,6 +59,7 @@ public class ClusterModelStats {
     _replicaStats = new HashMap<>();
     _leaderReplicaStats = new HashMap<>();
     _topicReplicaStats = new HashMap<>();
+    _topicLeaderStats = new HashMap<>();
     _numBrokers = 0;
     _numReplicasInCluster = 0;
     _numPartitionsWithOfflineReplicas = 0;
@@ -85,6 +87,7 @@ public class ClusterModelStats {
     numForReplicas(clusterModel);
     numForLeaderReplicas(clusterModel);
     numForAvgTopicReplicas(clusterModel);
+    numForAvgTopicLeaders(clusterModel);
     _utilizationMatrix = clusterModel.utilizationMatrix();
     _numSnapshotWindows = clusterModel.load().numWindows();
     _monitoredPartitionsRatio = clusterModel.monitoredPartitionsRatio();
@@ -125,6 +128,13 @@ public class ClusterModelStats {
    */
   public Map<Statistic, Number> topicReplicaStats() {
     return _topicReplicaStats;
+  }
+
+  /**
+   * @return Topic leader replica stats for the cluster instance that the object was populated with.
+   */
+  public Map<Statistic, Number> topicLeaderStats() {
+    return _topicLeaderStats;
   }
 
   /**
@@ -429,6 +439,46 @@ public class ClusterModelStats {
 
     _topicReplicaStats.put(Statistic.AVG, _topicReplicaStats.get(Statistic.AVG).doubleValue() / _numTopics);
     _topicReplicaStats.put(Statistic.ST_DEV, _topicReplicaStats.get(Statistic.ST_DEV).doubleValue() / _numTopics);
+  }
+
+  /**
+   * Generate statistics for leader topic replicas in the given cluster.
+   *
+   * @param clusterModel The state of the cluster.
+   */
+  private void numForAvgTopicLeaders(ClusterModel clusterModel) {
+    _topicLeaderStats.put(Statistic.AVG, 0.0);
+    _topicLeaderStats.put(Statistic.MAX, 0);
+    _topicLeaderStats.put(Statistic.MIN, Integer.MAX_VALUE);
+    _topicLeaderStats.put(Statistic.ST_DEV, 0.0);
+    int numAliveBrokers = clusterModel.aliveBrokers().size();
+    for (String topic : clusterModel.topics()) {
+      int maxTopicLeadersInBroker = 0;
+      int minTopicLeadersInBroker = Integer.MAX_VALUE;
+      for (Broker broker : clusterModel.brokers()) {
+        int numTopicLeadersInBroker = broker.numLeadersOfTopicInBroker(topic);
+        maxTopicLeadersInBroker = Math.max(maxTopicLeadersInBroker, numTopicLeadersInBroker);
+        minTopicLeadersInBroker = Math.min(minTopicLeadersInBroker, numTopicLeadersInBroker);
+      }
+      double avgTopicLeaders = ((double) clusterModel.numTopicLeaders(topic)) / numAliveBrokers;
+
+      // Standard deviation of leader replicas in alive brokers.
+      double variance = 0.0;
+      for (Broker broker : clusterModel.aliveBrokers()) {
+        variance += (Math.pow(broker.numLeadersOfTopicInBroker(topic) - avgTopicLeaders, 2)
+                / (double) numAliveBrokers);
+      }
+
+      _topicLeaderStats.put(Statistic.AVG, _topicLeaderStats.get(Statistic.AVG).doubleValue() + avgTopicLeaders);
+      _topicLeaderStats.put(Statistic.MAX,
+              Math.max(_topicLeaderStats.get(Statistic.MAX).intValue(), maxTopicLeadersInBroker));
+      _topicLeaderStats.put(Statistic.MIN,
+              Math.min(_topicLeaderStats.get(Statistic.MIN).intValue(), minTopicLeadersInBroker));
+      _topicLeaderStats.put(Statistic.ST_DEV, (Double) _topicLeaderStats.get(Statistic.ST_DEV) + Math.sqrt(variance));
+    }
+
+    _topicLeaderStats.put(Statistic.AVG, _topicLeaderStats.get(Statistic.AVG).doubleValue() / _numTopics);
+    _topicLeaderStats.put(Statistic.ST_DEV, _topicLeaderStats.get(Statistic.ST_DEV).doubleValue() / _numTopics);
   }
 
   /**

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Host.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Host.java
@@ -75,6 +75,21 @@ public class Host implements Serializable {
   }
 
   /**
+   * Get the number of leader replicas with the given topic name in this host.
+   *
+   * @param topic Name of the topic for which the number of leader replicas in this rack will be counted.
+   * @return Number of leader replicas with the given topic name in this host.
+   */
+  public int numTopicLeaders(String topic) {
+    int numTopicLeaders = 0;
+
+    for (Broker broker : _brokers.values()) {
+      numTopicLeaders += broker.numLeadersOfTopicInBroker(topic);
+    }
+    return numTopicLeaders;
+  }
+
+  /**
    * @return All the topics that have at least one partition on the host.
    */
   public Set<String> topics() {

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Rack.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/model/Rack.java
@@ -116,6 +116,21 @@ public class Rack implements Serializable {
   }
 
   /**
+   * Get the number of leader replicas with the given topic name in this rack.
+   *
+   * @param topic Name of the topic for which the number of leader replicas in this rack will be counted.
+   * @return Number of leader replicas with the given topic name in this rack.
+   */
+  public int numTopicLeaders(String topic) {
+    int numTopicLeaders = 0;
+
+    for (Host host : _hosts.values()) {
+      numTopicLeaders += host.numTopicLeaders(topic);
+    }
+    return numTopicLeaders;
+  }
+
+  /**
    * @return A set of topic names in the cluster.
    */
   public Set<String> topics() {

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/DeterministicClusterTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/DeterministicClusterTest.java
@@ -22,6 +22,7 @@ import com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal;
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal;
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal;
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicReplicaDistributionGoal;
+import com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicLeaderDistributionGoal;
 import com.linkedin.kafka.cruisecontrol.analyzer.kafkaassigner.KafkaAssignerDiskUsageDistributionGoal;
 import com.linkedin.kafka.cruisecontrol.analyzer.kafkaassigner.KafkaAssignerEvenRackAwareGoal;
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
@@ -111,6 +112,7 @@ public class DeterministicClusterTest {
                                                     LeaderReplicaDistributionGoal.class.getName(),
                                                     LeaderBytesInDistributionGoal.class.getName(),
                                                     TopicReplicaDistributionGoal.class.getName(),
+                                                    TopicLeaderDistributionGoal.class.getName(),
                                                     PreferredLeaderElectionGoal.class.getName());
 
     Properties props = KafkaCruiseControlUnitTestUtils.getKafkaCruiseControlProperties();

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/RandomClusterTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/analyzer/RandomClusterTest.java
@@ -21,6 +21,7 @@ import com.linkedin.kafka.cruisecontrol.analyzer.goals.PreferredLeaderElectionGo
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal;
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal;
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal;
+import com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicLeaderDistributionGoal;
 import com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicReplicaDistributionGoal;
 import com.linkedin.kafka.cruisecontrol.analyzer.kafkaassigner.KafkaAssignerDiskUsageDistributionGoal;
 import com.linkedin.kafka.cruisecontrol.analyzer.kafkaassigner.KafkaAssignerEvenRackAwareGoal;
@@ -85,6 +86,7 @@ public class RandomClusterTest {
                                                     LeaderReplicaDistributionGoal.class.getName(),
                                                     LeaderBytesInDistributionGoal.class.getName(),
                                                     TopicReplicaDistributionGoal.class.getName(),
+                                                    TopicLeaderDistributionGoal.class.getName(),
                                                     PreferredLeaderElectionGoal.class.getName());
 
     List<String> kafkaAssignerGoals = Arrays.asList(KafkaAssignerEvenRackAwareGoal.class.getName(),


### PR DESCRIPTION
This change adds new goal `TopicLeaderDistributionGoal` to Cruise Control. This goal does leadership movements to evenly balance the number of leader replicas between brokers, for each topic separately. 

The new goal is similar to the existing goal `TopicReplicaDistributionGoal` as it achieves a balance for each topic separately. The difference is that `TopicReplicaDistributionGoal` does replica movements and `TopicLeaderDistributionGoal` does leadership movements.

The new goal is also similar to `LeaderReplicaDistributionGoal` as it balances the number of leader replicas, but the new goal does this for each topic separately while `LeaderReplicaDistributionGoal` achieves an even number of total leader replicas hosted by each broker. The other difference is that `LeaderReplicaDistributionGoal` achieves the balance by doing both leadership movements and replica movements. `TopicLeaderDistributionGoal` does leadership movements only, with the expectation that it will be used in combination with other goals (such as `TopicReplicaDistribution`) that will do necessary replica movements.