### PR TITLE
Fix intra rebalance to not fail if there are brokers without JBOD

### DIFF
--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityConfigFileResolver.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/config/BrokerCapacityConfigFileResolver.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -251,7 +252,7 @@ public class BrokerCapacityConfigFileResolver implements BrokerCapacityConfigRes
   @SuppressWarnings("unchecked")
   private static Map<String, Double> getDiskCapacityByLogDir(Map<Resource, Object> brokerCapacity) {
     if (!isJBOD(brokerCapacity)) {
-      return null;
+      return Collections.emptyMap();
     }
 
     Map<String, String> stringDiskCapacityByLogDir = (Map<String, String>) brokerCapacity.get(Resource.DISK);


### PR DESCRIPTION
This PR fixes the intra broker rebalance feature to work even if the cluster contains some brokers that don't use the JBOD disk configuration. We're currently experimenting with JBOD on some brokers in the cluster, and we still want CC to balance the data between disks of these specific brokers.